### PR TITLE
Handling paths and datafolder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 .DS_Store
 ._*
-
 *.pyc
-data/
 

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,3 @@
+# ignore everything in this folder
+*
+!.gitignore

--- a/localRequests.py
+++ b/localRequests.py
@@ -6,9 +6,9 @@ import time
 import pdb
 
 timestamp = time.time()
-debug = False
 
-def get(url,params=None,timeout=0,source=None,verbose=False):
+
+def get(url,params=None,timeout=0,source=None,verbose=False, debug=False):
 	'''
 	* url is the classic post url
 	* params are the standard parameters to post to a url, and used as the key in the storage dict.
@@ -20,10 +20,9 @@ def get(url,params=None,timeout=0,source=None,verbose=False):
 	 	* remote: will force a pull and update of all local files, overwriting each one
 	  	* verbose: print out of posting requests and waiting time, every time it is required
 	'''
-	dirpath = '/Volumes/Internal/Documents/localRequest/data/'
+	dirpath = 'data/'
 	filePath = dirpath + url.replace('/','__') + '.pkl'
 	global timestamp
-	global debug
 	debug = verbose
 	if params is not None:
 		payload = makeParamPayload(params)


### PR DESCRIPTION
Create an empty data folder with a gitignore file for easier storage.

Change the data path from and absolute to looking at "data" folder at all times

Make debug an option in the get() function so it can be called from outside